### PR TITLE
fix: match female pronouns with word boundary

### DIFF
--- a/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
+++ b/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
@@ -10,6 +10,8 @@ import org.catalyst.biascorrect.PlatformConstants;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
+++ b/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
@@ -36,7 +36,9 @@ public class TriggerWordBiasDetector {
     private boolean hasFemalePronoun(String originalMessage) {
         boolean result = false;
         for (String word : FEMALE_PRONOUNS) {
-            if (originalMessage.contains(word)) {
+            Pattern p = Pattern.compile("\\b" + word + "\\b");
+            Matcher m = p.matcher(originalMessage);
+            if (m.find()) {
                 result = true;
                 break;
             }

--- a/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
+++ b/app/org/catalyst/biascorrect/algos/TriggerWordBiasDetector.java
@@ -66,7 +66,10 @@ public class TriggerWordBiasDetector {
         for (Map.Entry<String, String> entry : _triggerWordMap.entrySet()) {
             String word = entry.getKey();
             String correctedWord = entry.getValue();
-            if (correctedMessage.contains(word)) {
+            
+            Pattern p = Pattern.compile("\\b" + word + "\\b");
+            Matcher m = p.matcher(correctedMessage);
+            if (m.find()) {
                 correctedMessage = correctedMessage.replace(word, String.format("*%s*", correctedWord));
             }
         }


### PR DESCRIPTION
The current `hasFemalePronoun()` method is easily susceptible to false-positives.

e.g. `The weather is cold` -> `true`

This change only matches female pronouns that are separate words.

e.g. 
`The weather is cold` -> `false`
`she is cold` -> `true`